### PR TITLE
Support for a parent Makefile and Docker context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 REGISTRY_HOST=docker.io
 USERNAME=$(USER)
-NAME=$(shell basename $(PWD))
+NAME=$(shell basename $(CURDIR))
 
 RELEASE_SUPPORT := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/.make-release-support
 IMAGE=$(REGISTRY_HOST)/$(USERNAME)/$(NAME)
@@ -24,6 +24,9 @@ VERSION=$(shell . $(RELEASE_SUPPORT) ; getVersion)
 TAG=$(shell . $(RELEASE_SUPPORT); getTag)
 
 SHELL=/bin/bash
+
+DOCKER_BUILD_CONTEXT=.
+DOCKER_FILE_PATH=Dockerfile
 
 .PHONY: pre-build docker-build post-build build release patch-release minor-release major-release tag check-status check-release showver \
 	push pre-push do-push post-push
@@ -44,7 +47,7 @@ post-push:
 
 
 docker-build: .release
-	docker build $(DOCKER_BUILD_ARGS) -t $(IMAGE):$(VERSION) .
+	docker build $(DOCKER_BUILD_ARGS) -t $(IMAGE):$(VERSION) $(DOCKER_BUILD_CONTEXT) -f $(DOCKER_FILE_PATH)
 	@DOCKER_MAJOR=$(shell docker -v | sed -e 's/.*version //' -e 's/,.*//' | cut -d\. -f1) ; \
 	DOCKER_MINOR=$(shell docker -v | sed -e 's/.*version //' -e 's/,.*//' | cut -d\. -f2) ; \
 	if [ $$DOCKER_MAJOR -eq 1 ] && [ $$DOCKER_MINOR -lt 10 ] ; then \

--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ post-build:
 
 Now you can use the make build and release instructions to build these images.
 
+### Changing the build context and Dockerfile path and name
+
+Use the `DOCKER_BUILD_CONTEXT`variable to set the path to the context. Set `DOCKER_FILE_PATH` to change the path to the Dockerfile (file name included) you want to use. Using this in conjuction with the `pre-build` and `post-build` targets and a `.dockerignore` file allows you to modify the build context.
+
+```
+DOCKER_BUILD_CONTEXT=../..
+DOCKER_FILE_PATH=$(DOCKER_BUILD_CONTEXT)/docker/$(NAME)/some.Dockerfile
+
+pre-build: check-env-vars .dockerignore
+	cp .dockerignore $(DOCKER_BUILD_CONTEXT)
+
+post-build:
+	rm $(DOCKER_BUILD_CONTEXT)/.dockerignore
+```
+
 ### pre tag command
 If you want add the current release to a source file, you can add the property `pre\_tag\_command` to the .release file. 
 this command is executed when the .release file is updated and before the tag is placed. In the command @@RELEASE@@ is


### PR DESCRIPTION
- using $(CUR_DIR) in `NAME=$(shell basename $(CURDIR))` instead of passwords allows a parent Makefile above the siblings directory for multi-image option
- Added `DOCKER_BUILD_CONTEXT` and `DOCKER_FILE_PATH`, which enables the possibility of modifying the Docker context and the path and name to the Dockerfile